### PR TITLE
[FIX][13.0] v13_fix_web_responsive: fix preview image, pdf, video on phone

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -697,7 +697,7 @@ html .o_web_client .o_action_manager .o_action {
 .o_web_client.o_chatter_position_sided {
     .o_modal_fullscreen.o_document_viewer {
         // On-top of navbar
-        z-index: 10;
+        z-index: 1052;
 
         &.o_responsive_document_viewer {
             /* Show sided viewer on large screens */


### PR DESCRIPTION
Vì z-index của o_document_viewer (10) nhỏ hơn z-index của cửa sổ chat (1051) nên trên mobile app image, pdf, video hiển thị xuống dưới cửa sổ chat, người dùng sẽ không nhìn thấy image, pdf, video.
Link ticket: https://viindoo.com/web#active_id=792&cids=1&id=792&model=helpdesk.ticket&menu_id=